### PR TITLE
Fix persisting datasource selection choice

### DIFF
--- a/client/app/pages/queries/QuerySource.jsx
+++ b/client/app/pages/queries/QuerySource.jsx
@@ -134,9 +134,11 @@ function QuerySource(props) {
     // choose data source id for new queries
     if (dataSourcesLoaded && queryFlags.isNew) {
       const firstDataSourceId = dataSources.length > 0 ? dataSources[0].id : null;
+      const selectedDataSourceId = parseInt(localStorage.getItem("lastSelectedDataSourceId")) || null;
+
       handleDataSourceChange(
         chooseDataSourceId(
-          [query.data_source_id, localStorage.getItem("lastSelectedDataSourceId"), firstDataSourceId],
+          [query.data_source_id, selectedDataSourceId, firstDataSourceId],
           dataSources
         )
       );


### PR DESCRIPTION
Closes getredash/redash#5646.

We were already storing this in localStorage, however we weren't
accounting for the fact that it was stored as a string, rather than
an integer.
