### PR TITLE
Update PyMongo to version 4.3.3

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -6,7 +6,7 @@ influxdb==5.2.3
 mysqlclient==2.1.1
 oauth2client==4.1.3
 pyhive==0.6.1
-pymongo[tls,srv]==3.9.0
+pymongo[tls,srv]==4.3.3
 vertica-python==0.9.5
 td-client==1.0.0
 pymssql==2.1.5


### PR DESCRIPTION
## What type of PR is this? 

- [x] Dependency update

## Description

Just a simple dependency update, so we can see if PyMongo 4.3.3 builds without breaking

## How is this tested?

- [x] Unit tests (pytest, jest)
- [x] E2E Tests (Cypress)


## Related Tickets & Documents

#59 - Unsupported OP_QUERY command