### PR TITLE
Fix a typo for REDASH_FEATURE_POLICY env variable

### DIFF
--- a/redash/settings/__init__.py
+++ b/redash/settings/__init__.py
@@ -171,7 +171,7 @@ REFERRER_POLICY = os.environ.get(
 # an empty value.
 # See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy
 # for more information.
-FEATURE_POLICY = os.environ.get("REDASH_REFERRER_POLICY", "")
+FEATURE_POLICY = os.environ.get("REDASH_FEATURE_POLICY", "")
 
 MULTI_ORG = parse_boolean(os.environ.get("REDASH_MULTI_ORG", "false"))
 


### PR DESCRIPTION
Fixes a typo with the `REDASH_FEATURE_POLICY` environment variable