### PR TITLE
Downgrading dql from version 0.6.2 to 0.5.26.

### DIFF
--- a/requirements_all_ds.txt
+++ b/requirements_all_ds.txt
@@ -10,7 +10,8 @@ pymongo[tls,srv]==4.3.3
 vertica-python==0.9.5
 td-client==1.0.0
 pymssql==2.1.5
-dql==0.6.2
+# We can't upgrade dql==0.5.26 version as dql==0.6.2 newer versions require PostgreSQL > 10, but we target older versions at the moment.
+dql==0.5.26
 dynamo3==1.0.0
 boto3>=1.14.0,<1.15.0
 botocore>=1.13,<=1.17.55


### PR DESCRIPTION
Downgrading dql from version 0.6.2 to 0.5.26.
We can't upgrade dql==0.5.26 version as dql==0.6.2 newer versions require PostgreSQL > 10, but we target older versions at the moment.
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
