### PR TITLE
WIP: Copy the contents of requirements_all_ds.txt into requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ itsdangerous==1.1.0
 click==6.7
 MarkupSafe==1.1.1
 pyOpenSSL==19.0.0
-httplib2==0.14.0
+httplib2==0.15.0
 wtforms==2.2.1
 Flask-RESTful==0.3.7
 Flask-Login==0.4.1
@@ -64,3 +64,57 @@ werkzeug==0.16.1
 # ldap3==2.2.4
 Authlib==0.15.5
 advocate==1.0.0
+
+# Copied from requirements_all_ds.txt, as a test to see if it fixes the "missing data source libraries"
+# problem in our initial preview build
+google-api-python-client==1.7.11
+protobuf==3.18.3
+gspread==3.1.0
+impyla==0.16.0
+influxdb==5.2.3
+mysqlclient==2.1.1
+oauth2client==4.1.3
+pyhive==0.6.1
+pymongo[tls,srv]==4.3.3
+vertica-python==0.9.5
+td-client==1.0.0
+pymssql==2.1.5
+dql==0.6.2
+dynamo3==1.0.0
+boto3>=1.14.0,<1.15.0
+botocore>=1.13,<=1.17.55
+sasl>=0.1.3
+thrift>=0.8.0
+thrift_sasl>=0.1.0
+cassandra-driver==3.21.0
+memsql==3.2.0
+atsd_client==3.0.5
+simple_salesforce==0.74.3
+PyAthena>=1.5.0,<=1.11.5
+#pymapd==0.19.0
+qds-sdk>=1.9.6
+# ibm-db>=2.0.9
+pydruid==0.5.7
+requests_aws_sign==0.1.5
+snowflake-connector-python==3.0.2
+phoenixdb==0.7
+# certifi is needed to support MongoDB and SSL:
+certifi>=2019.9.11
+pydgraph==2.0.2
+azure-kusto-data==0.0.35
+pyexasol==0.12.0
+python-rapidjson==0.8.0
+pyodbc==4.0.28
+trino~=0.305
+cmem-cmempy==21.2.3
+xlrd==2.0.1
+openpyxl==3.0.7
+firebolt-sdk
+databend-sqlalchemy==0.2.4
+pandas==1.3.4
+nzpy>=1.15
+nzalchemy
+python-arango==6.1.0
+pinotdb>=0.4.5
+pyarrow==10.0.0
+


### PR DESCRIPTION
As per discussion to try and get our build to include all data sources:

  https://github.com/RedashCommunity/redash/issues/59#issuecomment-1599951891

Note that I have no idea if this will actually pass our CI as is, so this is more experimental than anything for now.

Also update httplib2 to version 0.15.0, as 0.14.0 is apparently too old (according to my local pip install).

When trying this out from the command line on my local Ubuntu 20.04 system, pip installs most of them but throws these errors:

  ERROR: boto3 1.14.63 has requirement botocore<1.18.0,>=1.17.63, but you'll have botocore 1.13.50 which is incompatible.
  ERROR: dql 0.6.2 has requirement botocore>=1.17.55, but you'll have botocore 1.13.50 which is incompatible.
  ERROR: dql 0.6.2 has requirement pyparsing==2.1.4, but you'll have pyparsing 2.3.0 which is incompatible.
  ERROR: snowflake-connector-python 3.0.2 has requirement charset-normalizer<3,>=2, but you'll have charset-normalizer 3.1.0 which is incompatible.
  ERROR: snowflake-connector-python 3.0.2 has requirement cryptography<41.0.0,>=3.1.0, but you'll have cryptography 2.8 which is incompatible.
  ERROR: firebolt-sdk 0.16.2 has requirement cryptography>=3.4.0, but you'll have cryptography 2.8 which is incompatible.
  ERROR: firebolt-sdk 0.16.2 has requirement python-dateutil>=2.8.2, but you'll have python-dateutil 2.8.0 which is incompatible.
  ERROR: firebolt-sdk 0.16.2 has requirement sqlparse>=0.4.2, but you'll have sqlparse 0.3.0 which is incompatible.
  ERROR: pinotdb 0.5.0 has requirement httpx<0.24.0,>=0.23.0, but you'll have httpx 0.24.0 which is incompatible.

We may need to drop those data sources in the short term to get things to a fully working state, then come back to them at some later point.