### PR TITLE
Remove pycrypto==2.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,6 @@ rq-scheduler==0.9.1
 jsonschema==3.1.1
 RestrictedPython==5.0
 pysaml2==6.5.2
-pycrypto==2.6.1
 python-dotenv==0.19.2
 funcy==1.13
 sentry-sdk>=0.14.3,<0.15.0


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
#66 
Remove pycrypto==2.6.1

I found that pycrypto==2.6.1 is no longer being used in our codebase, and we already have cryptography==2.8 to replace pycrypto==2.6.1.
## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
