### PR TITLE
use psycopg2-binary insted of  psycopg2==2.8.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ Flask-WTF==0.14.3
 passlib==1.7.1
 aniso8601==8.0.0
 blinker==1.4
-psycopg2==2.8.3
+psycopg2-binary
 python-dateutil==2.8.0
 pytz>=2019.3
 PyYAML==5.4


### PR DESCRIPTION
## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## Description
<!-- In case of adding / modifying a query runner, please specify which version(s) you expect are compatible. -->
#72 
[use psycopg2-binary insted of psycopg2==2.8.3](https://github.com/Avey777/RedashCommunity-redash/commit/d7ee55c81f590f28b92ad83fbdf3bba194111fa0)
## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [ ] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents
<!-- If applicable, please include a link to your documentation PR against getredash/website -->

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
