### PR TITLE
Update Simba ODBC driver for Databricks compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && \
 
 
 ARG TARGETPLATFORM
-ARG databricks_odbc_driver_url=https://databricks.com/wp-content/uploads/2.6.10.1010-2/SimbaSparkODBC-2.6.10.1010-2-Debian-64bit.zip
+ARG databricks_odbc_driver_url=https://databricks-bi-artifacts.s3.us-east-2.amazonaws.com/simbaspark-drivers/odbc/2.6.26/SimbaSparkODBC-2.6.26.1045-Debian-64bit.zip
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
   curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list \
@@ -74,11 +74,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
   && rm -rf /var/lib/apt/lists/* \
   && curl "$databricks_odbc_driver_url" --location --output /tmp/simba_odbc.zip \
   && chmod 600 /tmp/simba_odbc.zip \
-  && unzip /tmp/simba_odbc.zip -d /tmp/ \
-  && dpkg -i /tmp/SimbaSparkODBC-*/*.deb \
+  && unzip /tmp/simba_odbc.zip -d /tmp/simba \
+  && dpkg -i /tmp/simba/*.deb \
   && printf "[Simba]\nDriver = /opt/simba/spark/lib/64/libsparkodbc_sb64.so" >> /etc/odbcinst.ini \
   && rm /tmp/simba_odbc.zip \
-  && rm -rf /tmp/SimbaSparkODBC*; fi
+  && rm -rf /tmp/simba; fi
 
 WORKDIR /app
 


### PR DESCRIPTION
It appears that there was an upstream change to Databricks recently
which rendered it incompatibility with the (rather old) Simba ODBC
driver installed in the docker container. Updating the driver fixes
things on our end.

## What type of PR is this? 
<!-- Check all that apply, delete what doesn't apply. -->

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] New Query Runner (Data Source) 
- [ ] New Alert Destination
- [ ] Other

## How is this tested?

- [ ] Unit tests (pytest, jest)
- [ ] E2E Tests (Cypress)
- [x] Manually
- [ ] N/A

<!-- If Manually, please describe. -->

## Related Tickets & Documents

Here's the error we get with the current version, FWIW (started seeing this a couple days ago):

![image](https://github.com/getredash/redash/assets/20569/4ee69616-6de3-496c-adb2-6ce3c1bd1ca4)

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
